### PR TITLE
fix deployment on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 install:
   - npm ci
 script:
+  - npm run lint
   - npm run build
 deploy:
   provider: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ deploy:
   api_key:
     secure: GdyeN/MSH7Xj4WWAtgB0h/7tfryUMHmZEd8tqQgiFqMp1LigdlyIMRuQrF4VBew5uChNboz5kcsgKBhXrTa1IlJVyKcuBAUsDE/K510i+wcCbqzotlqZFO36c/1xv1RdO3LaLI4w5AcwtXRw2EoaOQ5sauxCwTs7cbqCe1WIo64o8SbOprnNmur9wQVlbHNTboa8gfVfb2OYTVKEeSqAHIFfXSrlsaZdGFg2vmmpSwqqm+ggrCTuuASvAeInRT5I1jVRLd5HAqkA25L8xTnJSWh9KH6MRDGUqeNWMgKGkt/P4xIS7+A11+6gG1gWS7b80izoMqzIbloYoa/NFyziV9IIQetXcxPjYNS8+AIobHE5ZsaJJLO21ju3c5KhxNoBjUryqnJmSnBYJYxuV7QjILczLjCoKgT+Nl3Esog3X3AsTDkQFs6frRtI46sTD3HSzgDqfRELHi5XuKGyELnqNwt3mjVu8IDn0yywhBAo6ZegUI+NQv/x2PkjroiJqNtv4VemUIuPqHKoxoCAoazRQBLz4hCqoyPThKEnPjc68HxQjs8BrylJ/HxaY2wjQwwl9A+l9ejhwnHNxrIDXaO1wF5GN/+Lc8MsYybCk+W2E15576P6c3eMTKFnYVm2vlK/zLv6J2BIrabENdvUolVV7NErA5hU4AY2wZate521KJA=
   on:
-    branch: beta
+    all_branches: true
     tags: true
 branches:
   only:


### PR DESCRIPTION
According to
https://stackoverflow.com/questions/27773026/skipping-deployment-with-the-npm-provider-because-this-branch-is-not-permitted-t
(answered by ex-liiper Odi ;)
this needs to be `all_branches: true` to actually work

At least, it didn’t work yesterday with `branch: beta` -> https://travis-ci.org/rokka-io/vue-rokka-image/builds/604643462

and also do linting during tests